### PR TITLE
New sender/receiver example and new configuration support.

### DIFF
--- a/etc/sndr-time.ini
+++ b/etc/sndr-time.ini
@@ -1,0 +1,43 @@
+[pigpio]
+# host. Default: os.environ.get('PIGPIO_HOST', 'localhost')
+#host=localhost
+
+# port. Default: os.environ.get('PIGPIO_HOST', 'localhost')
+#port=8888
+
+[nrf24]
+# ce_pin. Default: 25
+#ce_pin=25              
+
+# spi_channel. Default: MAIN_CE0. Values: MAIN_CE0 (0), MAIN_CE1 (1), AUX_CE0 (2), AUX_CE1 (3), AUX_CE2 (4)
+#spi_channel=MAIN_CE0   
+
+# spi_speed. Default: 50000  
+#spi_speed=5e4          
+
+# data_rate. Default: RATE_1MBTS. Values: RATE_1MBPS (0), RATE_2MBPS (1), RATE_250KBPS (2). 
+data_rate=RATE_250KBPS  
+
+# channel. Default: 76. Values: 0-124.
+channel=100             
+
+# payload_size. Default: MAX. Values: -1-32. ACK (-1), DYNAMIC (0), MIN (1), MAX (32).
+payload_size=DYNAMIC    
+
+# address_bytes. Default: 5. Values: 1-5
+#address_bytes=5        
+
+# crc_bytes. Default: BYTES_2. Values: DISABLED (0), BYTES_1 (1), BYTES_2 (2)
+#crc_bytes=BYTES_2      
+
+# pad. Default: 32. Values: any byte value.
+#pad=32                 
+
+tx_addr=DTCLI
+#rx_addr_0=
+#rx_addr_1=
+#rx_addr_2=
+#rx_addr_3=
+#rx_addr_4=
+#rx_addr_5=
+

--- a/test/rcvr-time.py
+++ b/test/rcvr-time.py
@@ -1,0 +1,52 @@
+import pigpio
+import time
+from datetime import datetime
+from nrf24 import *
+import struct
+from os import environ as env
+
+if __name__ == "__main__":
+    #
+    # Example receiving date/time information using NRF24.
+    #
+    print("Python NRF24 date/time receiver.")
+
+    # Connecto to a pigpio daemon.
+    print("Connecting to Raspberry:", env.get('PIGPIO_HOST', 'localhost'), env.get('PIGPIO_PORT', 8888))
+    pi = pigpio.pi(env.get('PIGPIO_HOST', 'localhost'), env.get('PIGPIO_PORT', 8888))
+    if not pi.connected:
+        print("Not connected to Raspberry PI...goodbye.")
+        exit()
+
+    # Create NRF24 object.
+    nrf = NRF24(pi, ce=25, payload_size=RF24_PAYLOAD.DYNAMIC, channel=100, data_rate=RF24_DATA_RATE.RATE_250KBPS)
+    nrf.open_reading_pipe(1, "DTCLI")
+
+    # We only look for the date/time protocol (0xfe)
+    protocol_formats = {0xfe: "<B4sHBBBBBB"}
+
+    count = 0
+    while True:
+
+        # As long as data is ready for processing, process it.
+        while nrf.data_ready():
+            pipe = nrf.data_pipe()
+            count += 1
+            now = datetime.now()
+            payload = nrf.get_payload()    
+            pls = ':'.join(f'{i:02x}' for i in payload)
+            protocol = payload[0]
+
+            print(f"{now:%Y-%m-%d %H:%M:%S.%f}: pipe: {pipe}, len: {len(payload)}, bytes: {pls}, count: {count}")
+            
+            fmt = protocol_formats.get(protocol)
+            if fmt is None:
+                print(f"{now:%Y-%m-%d %H:%M:%S.%f}: Unknown protocol {payload[0]}")
+            else:
+                try:
+                    print(f"{now:%Y-%m-%d %H:%M:%S.%f}: protocol: {protocol}, data: {struct.unpack(fmt, payload)}")
+                except:
+                    print(f"{now:%Y-%m-%d %H:%M:%S.%f}: Exception while unpacking payload of {len(payload)} bytes using {fmt}.")
+
+        # Sleep 500 ms.
+        time.sleep(0.5)

--- a/test/recv-01.py
+++ b/test/recv-01.py
@@ -10,7 +10,7 @@ if __name__ == "__main__":
     print("Python NRF24 Receiver 01")
     
     # Connect to pigpiod
-    pi = pigpio.pi(env['PIGPIO_HOST'])
+    pi = pigpio.pi(env.get('PIGPIO_HOST', 'localhost'), env.get('PIGPIO_PORT', 8888))
     if not pi.connected:
         print("Not connected to Raspberry PI...goodbye.")
         exit()
@@ -21,13 +21,12 @@ if __name__ == "__main__":
      
     nrf = NRF24(pi, ce=25, payload_size=RF24_PAYLOAD.DYNAMIC, channel=100, data_rate=RF24_DATA_RATE.RATE_250KBPS)
 #    nrf = NRF24(pi, ce=12, payload_size=RF24_PAYLOAD.DYNAMIC, channel=100, data_rate=RF24_DATA_RATE.RATE_250KBPS, spi_channel=SPI_CHANNEL.AUX_CE2)
-
+    
     # Listen on a bunch of adresses.
     nrf.open_reading_pipe(RF24_RX_ADDR.P1, [0x01, 0xCE, 0xFA, 0xBE, 0xBA])
     nrf.open_reading_pipe(RF24_RX_ADDR.P2, [0x02, 0xCE, 0xFA, 0xBE, 0xBA])
     nrf.open_reading_pipe(RF24_RX_ADDR.P3, [0x03, 0xCE, 0xFA, 0xBE, 0xBA])
     nrf.open_reading_pipe(RF24_RX_ADDR.P4, [0x04, 0xCE, 0xFA, 0xBE, 0xBA])
-    
 
     # Wait for device to settle and display the content of device registers.
     time.sleep(0.5)

--- a/test/sndr-time.py
+++ b/test/sndr-time.py
@@ -1,0 +1,37 @@
+import pigpio
+import time
+from datetime import datetime
+from nrf24 import *
+import struct
+from os import environ as env
+from configparser import ConfigParser, ExtendedInterpolation
+
+if __name__ == "__main__":
+    #
+    # Example sending date/time information using NRF24.
+    #
+    print("Python NRF24 date/time sender.")
+    
+    # Create NRF24 from configuration.
+    config = ConfigParser()
+    config.read('etc/sndr-time.ini')
+    nrf = NRF24.from_config(config)
+    
+    # Publish date/time information every 5 seconds.
+    delay = 5
+    published = 0
+    while True:
+        if (time.monotonic() - published >= delay):
+                # Get UTC timestamp.               
+                now = datetime.utcnow()
+                print(datetime.isoformat(now, timespec='milliseconds'))
+
+                # Create payload as bytes.
+                payload = struct.pack("<B4sHBBBBBB", 0xfe, b'TIME', now.year, now.month, now.day, \
+                    now.hour, now.minute, now.second, \
+                    now.weekday())
+                
+                # Send the payload to whoever may be listening.
+                nrf.send(payload)                
+                published = time.monotonic()                
+        time.sleep(0.5)


### PR DESCRIPTION
Added a sender/receiver scenario in test/sndr-time.py and test/rcvr-time.py that sends/receives date/time information.

Added support in NRF24 to create an instance based on configuration values using the static method from_config(...).